### PR TITLE
Restructure for Satyrographos 0.0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,35 +1,9 @@
-LIBDIR=/usr/local/share/satysfi
-PACKAGE_NAME=satysfi-class-stjarticle
-PACKAGE_DIR=$(LIBDIR)/$(PACKAGE_NAME)
+PACKAGE_NAME=class-stjarticle
 
-.PHONY: all
-.PHONY: doc install uninstall
-
-all:
+.PHONY: doc
 
 doc: stjarticle-demo.pdf
 
-install:
-	install -d "$(PACKAGE_DIR)/doc"
-	install -m 644 stjarticle-demo.{saty,pdf} "$(PACKAGE_DIR)/doc"
-	install -d "$(PACKAGE_DIR)/packages"
-	install -m 644 *.satyh "$(PACKAGE_DIR)/packages"
-
-uninstall:
-	rm -rf "$(PACKAGE_DIR)"
-
-#
-# Standard configuration for Satyrographos packages.
-#
-%.pdf: export SATYSFI_RUNTIME=$(PWD)/.satysfi
-%.pdf: %.saty install-package-local
-	eval `opam env` ; satysfi $<
-
-.PHONY: install-package-local install-package install-package-opam
-install-package-local: export SATYSFI_RUNTIME=$(PWD)/.satysfi
-install-package-local: install-package
-install-package: install-package-opam
-	eval `opam env` ; satyrographos install
-install-package-opam:
-	opam pin add --yes "file://$(PWD)"
-
+stjarticle-demo.pdf: stjarticle-demo.saty satysfi-$(PACKAGE_NAME).opam stjarticle.satyh Satyristes
+	opam pin add satysfi-$(PACKAGE_NAME).opam "file://$(PWD)" -y
+	satyrographos opam build -name $(PACKAGE_NAME)-doc

--- a/Satyristes
+++ b/Satyristes
@@ -1,0 +1,18 @@
+(version "0.0.2")
+(library
+  (name "class-stjarticle")
+  (version "1.3.2")
+  (sources
+    ((package "stjarticle.satyh" "stjarticle.satyh")))
+  (opam "satysfi-class-stjarticle.opam")
+  (compatibility ((satyrographos 0.0.1))))
+(libraryDoc
+  (name "class-stjarticle-doc")
+  (version "1.3.2")
+  (build
+    ((satysfi "stjarticle-demo.saty" "-o" "stjarticle-demo.pdf")))
+  (sources
+    ((doc "stjarticle-demo.pdf" "./stjarticle-demo.pdf")
+     (doc "stjarticle-demo.saty" "./stjarticle-demo.saty")))
+  (opam "satysfi-class-stjarticle-doc.opam")
+  (dependencies ((class-stjarticle ()))))

--- a/satysfi-class-stjarticle-doc.opam
+++ b/satysfi-class-stjarticle-doc.opam
@@ -1,13 +1,13 @@
 opam-version: "2.0"
-name: "satysfi-class-stjarticle"
+name: "satysfi-class-stjarticle-doc"
 version: "1.3.2"
-synopsis: "Extended SATySFi document package for Japanese"
+synopsis: "Document: Extended SATySFi document package for Japanese"
 description: """
-Extended SATySFi document package for Japanese.
+Document: Extended SATySFi document package for Japanese.
 
 This requires Satyrographos to install. See https://github.com/na4zagin3/satyrographos.
 """
-maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+maintainer: "puripuri2100 <puripuri2100@gmail.com>"
 authors: "puripuri2100 <puripuri2100@gmail.com>"
 license: "LGPL-3.0"
 homepage: "https://github.com/puripuri2100/stjarticle"
@@ -15,18 +15,25 @@ bug-reports: "https://github.com/puripuri2100/stjarticle/issues"
 dev-repo: "git+https://github.com/puripuri2100/stjarticle.git"
 depends: [
   "satysfi" {>= "0.0.3" & < "0.0.4"}
-  "satyrographos" {>= "0.0.1" & < "0.0.3"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-class-stjarticle" {= "1.3.2"}
+  "satysfi-lib-dist"
 ]
-build: [ ]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "class-stjarticle-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
 install: [
   ["satyrographos" "opam" "install"
-   "-name" "class-stjarticle"
+   "-name" "class-stjarticle-doc"
    "-prefix" "%{prefix}%"
    "-script" "%{build}%/Satyristes"]
 ]
 remove: [
   ["satyrographos" "opam" "uninstall"
-   "-name" "class-stjarticle"
+   "-name" "class-stjarticle-doc"
    "-prefix" "%{prefix}%"
    "-script" "%{build}%/Satyristes"]
 ]

--- a/stjarticle-demo.saty
+++ b/stjarticle-demo.saty
@@ -1,4 +1,4 @@
-@import: stjarticle
+@require: class-stjarticle/stjarticle
 %@require: stdjabook
 
 document (|


### PR DESCRIPTION
This PR adopts new Satyrographos 0.0.2 scheme.

- Add `Satyristes` a build file
- Update `dependency`, `install` and `uninstall` sections in the OPAM package file
- Fix `stjarticle-demo.saty` to follow the new package name schema
- Update `Makefile` with new Satyrographos command